### PR TITLE
Add devcontainer configuration for Scala development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "Scala Dev Container",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "service": "db",
+  "dockerComposeFile": "../docker-compose.yml",
+  "extensions": [
+    "scalameta.metals",
+    "scalameta.scalameta",
+    "scalameta.sbt",
+    "scalameta.scalafmt"
+  ],
+  "settings": {
+    "scalameta.scalafmt.configPath": "../.scalafmt.conf"
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM us-docker.pkg.dev/gitlab-runner-189405/gcr.io/docker-sbt
+
+# Set the working directory
+WORKDIR /workspace
+
+# Copy the project files
+COPY . /workspace
+
+# Set the entrypoint
+ENTRYPOINT ["sbt"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,16 @@ services:
       - ./docker/.pgdata:/var/lib/postgresql/data
     logging:
       driver: local
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+    environment:
+      MAASERTRACKER_DB_PORT: 5432
+      MAASERTRACKER_DB_HOST: db


### PR DESCRIPTION
Add development container configuration for Scala project.

* **Dockerfile**: Create a Dockerfile to set up the development environment with Scala, SBT, and other required tools. Use `us-docker.pkg.dev/gitlab-runner-189405/gcr.io/docker-sbt` as the base image. Set the working directory to `/workspace`, copy project files, and set the entrypoint to `sbt`.
* **.devcontainer/devcontainer.json**: Create a `devcontainer.json` file to configure the development container. Set the `Dockerfile` as the build context, configure the container to use the existing `docker-compose.yml` for the PostgreSQL service, and add necessary VS Code extensions for Scala development. Configure the container to use the existing `.scalafmt.conf` for Scala code formatting.
* **docker-compose.yml**: Update the `docker-compose.yml` file to include the PostgreSQL service for the development container. Add a new service `dev` with the build context, volumes, ports, dependencies, and environment variables.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nafg/maaser-tracker/pull/1?shareId=7c2391a0-f068-45f0-a661-4d447d8e1beb).